### PR TITLE
Make multiple weathers with the same name selectable

### DIFF
--- a/Weatherman/Gui/TabQuickControl.cs
+++ b/Weatherman/Gui/TabQuickControl.cs
@@ -77,6 +77,7 @@ namespace Weatherman
                     {
                         foreach (byte i in p.GetWeathers(Svc.ClientState.TerritoryType))
                         {
+                            ImGui.PushID(i.ToString());
                             var colored = false;
                             if (p.IsWeatherNormal(i, Svc.ClientState.TerritoryType))
                             {
@@ -88,6 +89,7 @@ namespace Weatherman
                                 p.SelectedWeather = i;
                             }
                             if (colored) ImGui.PopStyleColor(1);
+                            ImGui.PopID();
                         }
                         if (p.SelectedWeather != 255 && ImGui.Button("Reset weather##weather"))
                         {


### PR DESCRIPTION
A zone can have multiple weathers with an identical name, but the quick select currently doesn't let you pick any of the later identical-named weathers.